### PR TITLE
Replace TryInto with Into requirements

### DIFF
--- a/examples/sparse.rs
+++ b/examples/sparse.rs
@@ -65,8 +65,8 @@ impl GameState for State {
 
 fn main() {
     let context = BTermBuilder::simple80x50()
-        .with_font("vga8x16.png", 8, 16)
-        .with_sparse_console(80, 25, "vga8x16.png")
+        .with_font("vga8x16.png", 8u32, 16u32)
+        .with_sparse_console(80u32, 25u32, "vga8x16.png")
         .with_title("Bracket Terminal - Sparse Consoles")
         .build();
 

--- a/examples/textsprites.rs
+++ b/examples/textsprites.rs
@@ -75,8 +75,8 @@ fn main() {
     bracket_terminal::link_resource!(NYAN_CAT, "../resources/nyan.xp");
 
     let context = BTermBuilder::simple80x50()
-        .with_font("vga8x16.png", 8, 16)
-        .with_sparse_console(80, 25, "vga8x16.png")
+        .with_font("vga8x16.png", 8u32, 16u32)
+        .with_sparse_console(80u32, 25u32, "vga8x16.png")
         .with_title("Bracket Terminal Example - Text Sprites")
         .build();
 

--- a/examples/tiles.rs
+++ b/examples/tiles.rs
@@ -193,17 +193,17 @@ fn main() {
     // This initialization is a bit more complicated than the previous examples.
     let context = BTermBuilder::new()
         // We specify the CONSOLE dimensions
-        .with_dimensions(WIDTH, HEIGHT)
+        .with_dimensions(WIDTH as u32, HEIGHT as u32)
         // We specify the size of the tiles
-        .with_tile_dimensions(16, 16)
+        .with_tile_dimensions(16u32, 16u32)
         // We give it a window title
         .with_title("Bracket Example - Tiles")
         // We register our embedded "example_tiles.png" as a font.
-        .with_font("example_tiles.png", 16, 16)
+        .with_font("example_tiles.png", 16u32, 16u32)
         // We want a base simple console for the terrain background
-        .with_simple_console(WIDTH, HEIGHT, "example_tiles.png")
+        .with_simple_console(WIDTH as u32, HEIGHT as u32, "example_tiles.png")
         // We also want a sparse console atop it to handle moving the character
-        .with_sparse_console(WIDTH, HEIGHT, "example_tiles.png")
+        .with_sparse_console(WIDTH as u32, HEIGHT as u32, "example_tiles.png")
         // And we call the builder function
         .build();
 

--- a/src/initializer.rs
+++ b/src/initializer.rs
@@ -1,6 +1,5 @@
 use crate::prelude::{init_raw, BTerm, InitHints, SimpleConsole, SparseConsole, Font};
 use std::collections::HashMap;
-use std::convert::TryInto;
 
 /// Internal structure defining a font to be loaded.
 struct BuilderFont {
@@ -87,10 +86,10 @@ impl BTermBuilder {
     /// Provides an 8x8 terminal font simple console, with the specified dimensions as your starting point.
     pub fn simple<T>(width: T, height: T) -> Self
     where
-        T: TryInto<u32>,
+        T: Into<u32>,
     {
-        let w: u32 = width.try_into().ok().unwrap();
-        let h: u32 = height.try_into().ok().unwrap();
+        let w: u32 = width.into();
+        let h: u32 = height.into();
         let mut cb = BTermBuilder {
             width: w,
             height: h,
@@ -142,10 +141,10 @@ impl BTermBuilder {
     /// Provides a VGA-font simple terminal with the specified dimensions as your starting point.
     pub fn vga<T>(width: T, height: T) -> Self
     where
-        T: TryInto<u32>,
+        T: Into<u32>,
     {
-        let w: u32 = width.try_into().ok().unwrap();
-        let h: u32 = height.try_into().ok().unwrap();
+        let w: u32 = width.into();
+        let h: u32 = height.into();
         let mut cb = BTermBuilder {
             width: w,
             height: h,
@@ -172,20 +171,20 @@ impl BTermBuilder {
     /// Adds width/height dimensions to the BTerm builder.
     pub fn with_dimensions<T>(mut self, width: T, height: T) -> Self
     where
-        T: TryInto<u32>,
+        T: Into<u32>,
     {
-        self.width = width.try_into().ok().unwrap();
-        self.height = height.try_into().ok().unwrap();
+        self.width = width.into();
+        self.height = height.into();
         self
     }
 
     /// Overrides the default assumption for tile sizes. Needed for a raw initialization.
     pub fn with_tile_dimensions<T>(mut self, width: T, height: T) -> Self
     where
-        T: TryInto<u32>,
+        T: Into<u32>,
     {
-        self.tile_width = width.try_into().ok().unwrap();
-        self.tile_height = height.try_into().ok().unwrap();
+        self.tile_width = width.into();
+        self.tile_height = height.into();
         self
     }
 
@@ -205,13 +204,13 @@ impl BTermBuilder {
     /// Adds a font registration to the BTerm builder.
     pub fn with_font<S: ToString, T>(mut self, font_path: S, width: T, height: T) -> Self
     where
-        T: TryInto<u32>,
+        T: Into<u32>,
     {
         self.fonts.push(BuilderFont {
             path: font_path.to_string(),
             dimensions: (
-                width.try_into().ok().unwrap(),
-                height.try_into().ok().unwrap(),
+                width.into(),
+                height.into(),
             ),
         });
         self
@@ -220,11 +219,11 @@ impl BTermBuilder {
     /// Adds a simple console layer to the BTerm builder.
     pub fn with_simple_console<S: ToString, T>(mut self, width: T, height: T, font: S) -> Self
     where
-        T: TryInto<u32>,
+        T: Into<u32>,
     {
         self.consoles.push(ConsoleType::SimpleConsole {
-            width: width.try_into().ok().unwrap(),
-            height: height.try_into().ok().unwrap(),
+            width: width.into(),
+            height: height.into(),
             font: font.to_string(),
         });
         self
@@ -243,11 +242,11 @@ impl BTermBuilder {
     /// Adds a sparse console layer to the BTerm builder.
     pub fn with_sparse_console<S: ToString, T>(mut self, width: T, height: T, font: S) -> Self
     where
-        T: TryInto<u32>,
+        T: Into<u32>,
     {
         self.consoles.push(ConsoleType::SparseConsole {
-            width: width.try_into().ok().unwrap(),
-            height: height.try_into().ok().unwrap(),
+            width: width.into(),
+            height: height.into(),
             font: font.to_string(),
         });
         self
@@ -256,11 +255,11 @@ impl BTermBuilder {
     /// Adds a sparse console with no bg rendering layer to the BTerm builder.
     pub fn with_sparse_console_no_bg<S: ToString, T>(mut self, width: T, height: T, font: S) -> Self
     where
-        T: TryInto<u32>,
+        T: Into<u32>,
     {
         self.consoles.push(ConsoleType::SparseConsoleNoBg {
-            width: width.try_into().ok().unwrap(),
-            height: height.try_into().ok().unwrap(),
+            width: width.into(),
+            height: height.into(),
             font: font.to_string(),
         });
         self

--- a/src/multi_tile_sprite.rs
+++ b/src/multi_tile_sprite.rs
@@ -1,5 +1,4 @@
 use crate::prelude::{DrawBatch, BTerm, Tile, Console, string_to_cp437, XpFile};
-use std::convert::TryInto;
 use bracket_color::prelude::{RGB, ColorPair};
 use bracket_geometry::prelude::Point;
 
@@ -13,10 +12,10 @@ impl MultiTileSprite {
     /// Generates a sprite from an input string, divided into width x height sizes.
     pub fn from_string<S: ToString, T>(content: S, width: T, height: T) -> Self
     where
-        T: TryInto<i32>,
+        T: Into<i32>,
     {
-        let w: i32 = width.try_into().ok().unwrap();
-        let h: i32 = height.try_into().ok().unwrap();
+        let w: i32 = width.into();
+        let h: i32 = height.into();
         let content_s = content.to_string();
 
         let bytes = string_to_cp437(content_s);
@@ -44,10 +43,10 @@ impl MultiTileSprite {
         bg: &[RGB],
     ) -> Self
     where
-        T: TryInto<i32>,
+        T: Into<i32>,
     {
-        let w: i32 = width.try_into().ok().unwrap();
-        let h: i32 = height.try_into().ok().unwrap();
+        let w: i32 = width.into();
+        let h: i32 = height.into();
         let content_s = content.to_string();
 
         let bytes = string_to_cp437(content_s);


### PR DESCRIPTION
This looks like an awesome library!

I noticed you were calling `ok().unwrap()` on values that implemented `TryInto`. I thought it might be better to instead require types that implement `Into`, as the user will then receive a compiler error if they use a type that cannot convert, instead of a panic at runtime. If they need to use a value that can't always convert to `u32` (as I had to change in `examples/tiles`), they will be writing the panicking code at their level, making debugging failed conversions a bit easier.

Alternatively, the functions I changed could return a `Result` type, so you could propagate failed integer conversions upwards to the user. If you think that's a better solution, I could make that change instead.